### PR TITLE
Improve makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,17 +30,17 @@ bibliography update-bib:
 thesis:
 	@$(MAKE) -C thesis pdf
 
-project:
+project: check-node check-soffice
 	@$(MAKE) -C project pdf
 
 papers:
 	@$(MAKE) -C papers pdf
 
-slides:
+slides: check-marp
 	@$(MAKE) -C slides pdf
 
 # Dependency checks
-check-dependencies: check-r check-tectonic check-spellcheck check-marp
+check-dependencies: check-node check-r check-tectonic check-spellcheck
 
 check-node:
 	@command -v node >/dev/null 2>&1 || { echo "Error: Node.js is not installed."; exit 1; }


### PR DESCRIPTION
This pull request updates the `Makefile` to improve dependency management and ensure required tools are checked before building various targets. The most important changes are grouped below:

Dependency checks:

* Added `check-node` and `check-soffice` as prerequisites for the `project` target to ensure Node.js and LibreOffice are present before building project PDFs.
* Added `check-marp` as a prerequisite for the `slides` target to ensure Marp is available before building slides PDFs.
* Updated the `check-dependencies` target to include `check-node` and removed `check-marp`, reflecting a more accurate set of global build dependencies.