### PR TITLE
Added feature to use textidote to analyze latex documents, close #8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Install Node dependencies
         run: npm install
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - name: Install aspell with Spanish dictionary
         run: |
           sudo apt-get update
@@ -64,6 +70,11 @@ jobs:
       - name: Set up Marp
         run: npm install -g @marp-team/marp-cli
 
+      - name: Install TeXtidote
+        run: |
+          mkdir -p tools
+          curl -sSL https://github.com/sylvainhalle/textidote/releases/download/v0.8.3/textidote.jar -o tools/textidote.jar
+
       - name: Install LibreOffice (headless) + fonts
         run: |
           sudo apt-get update
@@ -74,7 +85,11 @@ jobs:
       - name: Generate PDFs
         run: make all
 
-      - name: Archive outputs (PDFs & docx)
+      - name: Run TeXtidote checks
+        run: make textidote
+        continue-on-error: true
+
+      - name: Archive outputs (PDFs, docx, reports)
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
@@ -82,6 +97,8 @@ jobs:
           path: |
             output/**/*.pdf
             output/**/*.docx
+            output/textidote/**/*.txt
+          if-no-files-found: warn
 
       - name: Build metadata
         id: meta
@@ -94,6 +111,7 @@ jobs:
           artifacts: |
             output/**/*.pdf
             output/**/*.docx
+            output/textidote/**/*.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
           tag: pre-release
@@ -106,7 +124,10 @@ jobs:
         if: github.event_name == 'release'
         uses: ncipollo/release-action@v1
         with:
-          artifacts: 'output/**/*.pdf'
+          artifacts: |
+            output/**/*.pdf
+            output/**/*.docx
+            output/textidote/**/*.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.release.tag_name }}
           allowUpdates: true

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # Ignore output PDFs
 output/
+tools/
 
 # Ignore temporary files
 *.tmp

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,15 @@ OUTPUT_DIR ?= $(ROOT_DIR)/output
 ZOTERO_BIB_URL ?= https://api.zotero.org/groups/5784268/items/top?format=biblatex
 BIB_FILE ?= $(ROOT_DIR)/bibliography/references.bib
 SPELLCHECK ?= aspell
+TOOLS_DIR ?= $(ROOT_DIR)/tools
+TEXTIDOTE_JAR ?= $(TOOLS_DIR)/textidote.jar
+TEXTIDOTE_LANG ?= es
+TEXTIDOTE_OUTDIR ?= $(OUTPUT_DIR)/textidote
 
 export ROOT_DIR OUTPUT_DIR ZOTERO_BIB_URL BIB_FILE SPELLCHECK
 
 .PHONY: all bibliography thesis project papers slides clean lint update-bib \
+	textidote textidote-thesis textidote-papers download-textidote \
 	check-dependencies check-node check-r check-tectonic check-spellcheck \
 	check-marp check-soffice help
 
@@ -87,6 +92,60 @@ clean:
 lint:
 	@$(MAKE) -C thesis lint
 
+textidote: textidote-thesis textidote-papers
+
+define ensure_textidote
+	@if [ ! -f "$(TEXTIDOTE_JAR)" ]; then \
+		echo "Error: TeXtidote not found at $(TEXTIDOTE_JAR)."; \
+		echo "Download it with 'make download-textidote' or set TEXTIDOTE_JAR."; \
+		exit 1; \
+	fi
+endef
+
+download-textidote:
+	@mkdir -p $(TOOLS_DIR)
+	@curl -sSL https://github.com/sylvainhalle/textidote/releases/download/v0.8.3/textidote.jar -o $(TEXTIDOTE_JAR)
+	@echo "TeXtidote downloaded to $(TEXTIDOTE_JAR)"
+
+textidote-thesis:
+	$(call ensure_textidote)
+	@mkdir -p $(TEXTIDOTE_OUTDIR)
+	@echo "Running TeXtidote on thesis/thesis.tex"
+	@java -jar $(TEXTIDOTE_JAR) --check $(TEXTIDOTE_LANG) --read-all --output singleline --no-color thesis/thesis.tex \
+	  > $(TEXTIDOTE_OUTDIR)/thesis.txt || true
+
+textidote-papers:
+	$(call ensure_textidote)
+	@mkdir -p $(TEXTIDOTE_OUTDIR)/papers
+	@if [ -n "$(shell find papers -type f -name '*.Rnw')" ]; then \
+		echo "Analyzing LaTeX-based papers with TeXtidote"; \
+		for src in $(shell find papers -type f -name '*.Rnw'); do \
+			rel=$${src#papers/}; \
+			out="$(TEXTIDOTE_OUTDIR)/papers/$${rel%.*}.txt"; \
+			outdir=$$(dirname "$$out"); \
+			mkdir -p "$$outdir"; \
+			echo "  -> $$src"; \
+			java -jar $(TEXTIDOTE_JAR) --check $(TEXTIDOTE_LANG) --read-all --output singleline --no-color "$$src" \
+			  > "$$out" || true; \
+		done; \
+	else \
+		echo "No .Rnw papers found for TeXtidote."; \
+	fi
+	@if [ -n "$(shell find papers -type f -name '*.Rmd')" ]; then \
+		echo "Analyzing Markdown-based papers with TeXtidote"; \
+		for src in $(shell find papers -type f -name '*.Rmd'); do \
+			rel=$${src#papers/}; \
+			out="$(TEXTIDOTE_OUTDIR)/papers/$${rel%.*}.txt"; \
+			outdir=$$(dirname "$$out"); \
+			mkdir -p "$$outdir"; \
+			echo "  -> $$src"; \
+			java -jar $(TEXTIDOTE_JAR) --type md --check $(TEXTIDOTE_LANG) --output singleline --no-color "$$src" \
+			  > "$$out" || true; \
+		done; \
+	else \
+		echo "No .Rmd papers found for TeXtidote."; \
+	fi
+
 help:
 	@echo "Available commands:"
 	@echo "  all           - Build bibliography, thesis, project, papers and slides"
@@ -96,6 +155,7 @@ help:
 	@echo "  papers        - Build PDFs for all papers"
 	@echo "  slides        - Build slide decks"
 	@echo "  lint          - Check LaTeX code style and spelling for the thesis"
+	@echo "  textidote     - Run TeXtidote analysis on thesis and papers"
 	@echo "  clean         - Remove generated artifacts"
 	@echo ""
 	@echo "Dependency helpers:"
@@ -105,3 +165,6 @@ help:
 	@echo "  check-spellcheck"
 	@echo "  check-marp"
 	@echo "  check-soffice"
+	@echo ""
+	@echo "Utilities:"
+	@echo "  download-textidote - Fetch TeXtidote jar into tools/"


### PR DESCRIPTION
This pull request adds TeXtidote integration for grammar and style checking to the documentation build process. The main changes include updating the GitHub Actions workflow to install and run TeXtidote, modifying the `Makefile` to support TeXtidote analysis, and ensuring TeXtidote reports are generated and archived alongside existing outputs.

**TeXtidote Integration:**

* The `.github/workflows/docs.yml` workflow now installs Java and downloads the TeXtidote jar, then runs TeXtidote checks as part of the build process. TeXtidote output reports are archived with other build artifacts and included in releases. 

**Makefile Enhancements:**

* New Makefile targets (`textidote`, `textidote-thesis`, `textidote-papers`, `download-textidote`) allow running TeXtidote analysis on the thesis and papers, and downloading the TeXtidote jar if needed. 