### PR TITLE
Fix the makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ slides: check-marp
 	@$(MAKE) -C slides pdf
 	@$(MAKE) -C slides site
 
+serve: check-marp
+	@$(MAKE) -C slides serve
+
 # Dependency checks
 check-dependencies: check-node check-r check-tectonic check-spellcheck
 

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -54,7 +54,7 @@ $(SLIDES_OUTPUT_DIR)/%.pdf: %.md | prepare assets
 	@marp --html --theme-set themes/ --allow-local-files --base-dir "$(ROOT_DIR)" --pdf $< -o $@
 
 serve: assets
-	marp --server --watch --allow-local-files --input-dir . --base-dir "$(ROOT_DIR)"
+	marp --server --watch --allow-local-files --input-dir . --base-dir "$(ROOT_DIR)" --html
 
 check-marp:
 ifndef MARP


### PR DESCRIPTION
This pull request adds support for serving Marp slides with HTML rendering and improves the workflow for serving slides locally. The main changes are focused on enhancing the slide serving process and updating the Makefile targets.

**Slide serving improvements:**

* Added a new `serve` target to the top-level `Makefile`, which runs `check-marp` before serving the slides, ensuring dependencies are checked before starting the server.
* Modified the `serve` target in `slides/Makefile` to include the `--html` flag when running the Marp server, enabling HTML rendering for slides served locally.