### PR TITLE
Fix the chapters

### DIFF
--- a/slides/01_investigation_plan.md
+++ b/slides/01_investigation_plan.md
@@ -64,10 +64,11 @@ NOTAS AL ORADOR:
 0. [Título](#1)
 1. [Introducción](#4)
 2. [El problema](#6)
-3. [La solución](#10)
+3. [La solución](#9)
 4. [El plan](#14)
 5. [El impacto](#18)
-6. [Conclusiones](#18)
+6. [Conclusiones](#20)
+
 
 <!--
 NOTAS AL ORADOR:
@@ -599,7 +600,7 @@ NOTAS AL ORADOR:
 
 <!-- _class: chapter -->
 
-# Conclusiones
+# 6. Conclusiones
 
 ## Más allá de eXeLearning
 


### PR DESCRIPTION
This pull request makes minor adjustments to the slide navigation and section headings in the `slides/01_investigation_plan.md` file to improve consistency and clarity.

* Slide navigation: Updated the section references in the navigation list to ensure they point to the correct slide numbers. (`slides/01_investigation_plan.md`)
* Section headings: Changed the heading for the conclusions section to include its index, aligning it with the format used for other sections. (`slides/01_investigation_plan.md`)